### PR TITLE
Fix README cloning instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cd workspace
 
 ```bash
 git clone https://github.com/semba-yui/sample-mysql-rdb.git
-cd densin-rdb
+cd sample-mysql-rdb
 ```
 
 ### 3. mise を用いて開発環境をセットアップする


### PR DESCRIPTION
## Summary
- correct the repository directory name in README

## Testing
- `grep -R "densin" -n`
